### PR TITLE
FEATURE2 - use env variables default (if not supplied via script/config)

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -190,16 +190,26 @@ ask_config() {
 write_config_file() {
     cat >${1} <<EOT
 {
-  "core": {
+ "core": {
     "metrics": {
-      "instance": "$HOSTNAME",
-      "comment": "$METRICS_COMMENT",
-      "push": "$PUSHMETRICS"
+    "instance": "$HOSTNAME",
+    "comment": "$METRICS_COMMENT",
+    "push": "$PUSHMETRICS"
     }
-  },
-  "spn": {
+},
+"spn": {
     "publicHub": {
-      "name": "$HOSTNAME"
+    "name": "$NAME",
+    "group": "$GROUP",
+    "contactAddress": "$CONTACTADDRESS",
+    "contactService": "$CONTACTSERVICE",
+    "hosters: "$HOSTERS",
+    "datacenter": "$DATACENTER",
+    "ip4": "$IP4",
+    "ip6": "$IP6",
+    "transports": "$TRANSPORTS",
+    "entry": "$ENTRY",
+    "exit": "$EXIT"
     }
   }
 }


### PR DESCRIPTION
this is for easy use with docker(-compose).
in future pullrequests i will post more about the use of docker to run the community node.

**please merge FEATURE1 first** #174 


**concept docker-compose**
```yaml
version: '3'
services:
  spn-node:
    container_name: SPN_Community_Node
    image: dockerteun/spn-community-node:latest
    ports:
      - 80
      - 17
    environment:
      - NAME=value            # REQUIRED Set the name of the node.
    #  - GROUP=value           # OPTIONAL Person or organisation, who is in control of the node (should be same for all nodes of this person or organisation).
    #  - CONTACTADDRESS=value  # OPTIONAL Contact possibility (recommended, but optional).
    #  - CONTACTSERVICE=value  # OPTIONAL Type of service of the contact address, if not email.
      - HOSTERS=Community     # REQUIRED Hosters - supply chain (reseller, hosting provider, datacenter operator, …).
    #  - DATACENTER=value      # OPTIONAL Datacenter in the format of COUNTRYCODE-COMPANY-INTERNALCODE (eg: DE-Hetzner-FSN1-DC5)
      - IP4=value             # REQUIRED IPv4 address must be global and accessible.
    #  - IP6=value             # OPTIONAL IPv6 address must be global and accessible.
    #  - TRANSPORTS=value      # OPTIONAL Define available protocols for communicating with other nodes and clients. Leave undefined to use defaults.
    #  - ENTRY=value           # OPTIONAL Set an entry policy (for clients) with the same syntax as rules.
    #  - EXIT=value            # OPTIONAL Set an exit policy (for destinations) with the same syntax as rules. The default is to block TCP/25 (SMTP) traffic.
    #  - METRICS_COMMENT=value # OPTIONAL Set an comment for the metricscollection?!
```